### PR TITLE
chromium: enable headless platform again

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-x11_95.0.4638.69.bb
+++ b/meta-chromium/recipes-browser/chromium/chromium-x11_95.0.4638.69.bb
@@ -22,6 +22,7 @@ DEPENDS += "\
 GN_ARGS += "\
         ozone_auto_platforms=false \
         ozone_platform_x11=true \
+        ozone_platform_headless=true \
 "
 
 # Compatibility glue while we have both chromium-x11 and


### PR DESCRIPTION
For testing and perhaps other workflows, we should allow headless mode.
This avoids the error:
# chromium --no-sandbox --headless https://html5test.com
[1117/063144.834204:FATAL:platform_selection.cc(45)] Invalid ozone platform: headless
Trace/breakpoint trap